### PR TITLE
Cross and lateral join pushdown with unnest or json - local

### DIFF
--- a/benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark
+++ b/benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark
@@ -1,0 +1,14 @@
+# name: benchmark/micro/optimizer/unnest_join_filter_pushdown.benchmark
+# description: Benchmark filter pushdown with unnest
+# group: [optimizer]
+
+name Unnest Filter Pushdown
+group micro
+subgroup optimizer
+
+load
+CREATE TABLE test_table as
+SELECT s.i as id,  [1, 2, 3]::bigint[] AS VALUES FROM generate_series(1, 10000000) AS s(i);
+
+run
+SELECT id, value FROM test_table CROSS JOIN UNNEST(values) AS values(value) WHERE id = 87100;

--- a/src/include/duckdb/optimizer/filter_pushdown.hpp
+++ b/src/include/duckdb/optimizer/filter_pushdown.hpp
@@ -97,7 +97,7 @@ private:
 	//! Adds a filter to the set of filters. Returns FilterResult::UNSATISFIABLE if the subtree should be stripped, or
 	//! FilterResult::SUCCESS otherwise
 
-	unique_ptr<LogicalOperator> FilterPushdownUnnestWithDelimJoin(unique_ptr<LogicalOperator> op);
+	unique_ptr<LogicalOperator> PushFiltersIntoDelimJoin(unique_ptr<LogicalOperator> op);
 	FilterResult AddFilter(unique_ptr<Expression> expr);
 	//! Extract filter bindings to compare them with expressions in an operator and determine if the filter
 	//! can be pushed down

--- a/src/include/duckdb/optimizer/filter_pushdown.hpp
+++ b/src/include/duckdb/optimizer/filter_pushdown.hpp
@@ -96,6 +96,8 @@ private:
 	unique_ptr<LogicalOperator> FinishPushdown(unique_ptr<LogicalOperator> op);
 	//! Adds a filter to the set of filters. Returns FilterResult::UNSATISFIABLE if the subtree should be stripped, or
 	//! FilterResult::SUCCESS otherwise
+
+	unique_ptr<LogicalOperator> FilterPushdownUnnestWithDelimJoin(unique_ptr<LogicalOperator> op);
 	FilterResult AddFilter(unique_ptr<Expression> expr);
 	//! Extract filter bindings to compare them with expressions in an operator and determine if the filter
 	//! can be pushed down

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_join.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
+#include "duckdb/planner/operator/logical_empty_result.hpp"
 #include "duckdb/planner/operator/logical_window.hpp"
 
 namespace duckdb {

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -317,7 +317,6 @@ unique_ptr<LogicalOperator> FilterPushdown::FinishPushdown(unique_ptr<LogicalOpe
 				i--;
 				break;
 			}
-
 		}
 	}
 

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -276,6 +276,51 @@ unique_ptr<LogicalOperator> FilterPushdown::PushFinalFilters(unique_ptr<LogicalO
 }
 
 unique_ptr<LogicalOperator> FilterPushdown::FinishPushdown(unique_ptr<LogicalOperator> op) {
+	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		for (idx_t i = 0; i < filters.size(); i++) {
+			auto &f = *filters[i];
+			for (auto &child : op->children) {
+				FilterPushdown pushdown(optimizer, convert_mark_joins);
+
+				// check if filter bindings can be applied to the child bindings.
+				auto child_bindings = child->GetColumnBindings();
+				unordered_set<idx_t> child_bindings_table;
+				for (auto &binding : child_bindings) {
+					child_bindings_table.insert(binding.table_index);
+				}
+
+				// Check if ALL bindings of the filter are present in the child
+				bool should_push = true;
+				for (auto &binding : f.bindings) {
+					if (child_bindings_table.find(binding) == child_bindings_table.end()) {
+						should_push = false;
+						break;
+					}
+				}
+
+				if (!should_push) {
+					continue;
+				}
+
+				// copy the filter
+				auto filter_copy = f.filter->Copy();
+				if (pushdown.AddFilter(std::move(filter_copy)) == FilterResult::UNSATISFIABLE) {
+					return make_uniq<LogicalEmptyResult>(std::move(op));
+				}
+
+				// push the filter into the child.
+				pushdown.GenerateFilters();
+				child = pushdown.Rewrite(std::move(child));
+
+				// Don't push same filter again
+				filters.erase_at(i);
+				i--;
+				break;
+			}
+
+		}
+	}
+
 	// unhandled type, first perform filter pushdown in its children
 	for (auto &child : op->children) {
 		FilterPushdown pushdown(optimizer, convert_mark_joins);

--- a/src/optimizer/filter_pushdown.cpp
+++ b/src/optimizer/filter_pushdown.cpp
@@ -276,7 +276,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushFinalFilters(unique_ptr<LogicalO
 	return AddLogicalFilter(std::move(op), std::move(expressions));
 }
 
-unique_ptr<LogicalOperator> FilterPushdown::FilterPushdownUnnestWithDelimJoin(unique_ptr<LogicalOperator> op) {
+unique_ptr<LogicalOperator> FilterPushdown::PushFiltersIntoDelimJoin(unique_ptr<LogicalOperator> op) {
 	for (idx_t i = 0; i < filters.size(); i++) {
 		auto &f = *filters[i];
 		for (auto &child : op->children) {
@@ -322,50 +322,6 @@ unique_ptr<LogicalOperator> FilterPushdown::FilterPushdownUnnestWithDelimJoin(un
 }
 
 unique_ptr<LogicalOperator> FilterPushdown::FinishPushdown(unique_ptr<LogicalOperator> op) {
-	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
-		for (idx_t i = 0; i < filters.size(); i++) {
-			auto &f = *filters[i];
-			for (auto &child : op->children) {
-				FilterPushdown pushdown(optimizer, convert_mark_joins);
-
-				// check if filter bindings can be applied to the child bindings.
-				auto child_bindings = child->GetColumnBindings();
-				unordered_set<idx_t> child_bindings_table;
-				for (auto &binding : child_bindings) {
-					child_bindings_table.insert(binding.table_index);
-				}
-
-				// Check if ALL bindings of the filter are present in the child
-				bool should_push = true;
-				for (auto &binding : f.bindings) {
-					if (child_bindings_table.find(binding) == child_bindings_table.end()) {
-						should_push = false;
-						break;
-					}
-				}
-
-				if (!should_push) {
-					continue;
-				}
-
-				// copy the filter
-				auto filter_copy = f.filter->Copy();
-				if (pushdown.AddFilter(std::move(filter_copy)) == FilterResult::UNSATISFIABLE) {
-					return make_uniq<LogicalEmptyResult>(std::move(op));
-				}
-
-				// push the filter into the child.
-				pushdown.GenerateFilters();
-				child = pushdown.Rewrite(std::move(child));
-
-				// Don't push same filter again
-				filters.erase_at(i);
-				i--;
-				break;
-			}
-		}
-	}
-
 	// unhandled type, first perform filter pushdown in its children
 	for (auto &child : op->children) {
 		FilterPushdown pushdown(optimizer, convert_mark_joins);

--- a/src/optimizer/pushdown/pushdown_inner_join.cpp
+++ b/src/optimizer/pushdown/pushdown_inner_join.cpp
@@ -14,7 +14,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownInnerJoin(unique_ptr<Logical
 	auto &join = op->Cast<LogicalJoin>();
 	D_ASSERT(join.join_type == JoinType::INNER);
 	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
-		op = FilterPushdownUnnestWithDelimJoin(std::move(op));
+		op = PushFiltersIntoDelimJoin(std::move(op));
 		return FinishPushdown(std::move(op));
 	}
 	// inner join: gather all the conditions of the inner join and add to the filter list

--- a/src/optimizer/pushdown/pushdown_inner_join.cpp
+++ b/src/optimizer/pushdown/pushdown_inner_join.cpp
@@ -14,6 +14,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownInnerJoin(unique_ptr<Logical
 	auto &join = op->Cast<LogicalJoin>();
 	D_ASSERT(join.join_type == JoinType::INNER);
 	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		op = FilterPushdownUnnestWithDelimJoin(std::move(op));
 		return FinishPushdown(std::move(op));
 	}
 	// inner join: gather all the conditions of the inner join and add to the filter list

--- a/src/optimizer/pushdown/pushdown_left_join.cpp
+++ b/src/optimizer/pushdown/pushdown_left_join.cpp
@@ -78,6 +78,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownLeftJoin(unique_ptr<LogicalO
                                                              unordered_set<idx_t> &right_bindings) {
 	auto &join = op->Cast<LogicalJoin>();
 	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		op = FilterPushdownUnnestWithDelimJoin(std::move(op));
 		return FinishPushdown(std::move(op));
 	}
 	FilterPushdown left_pushdown(optimizer, convert_mark_joins), right_pushdown(optimizer, convert_mark_joins);

--- a/src/optimizer/pushdown/pushdown_left_join.cpp
+++ b/src/optimizer/pushdown/pushdown_left_join.cpp
@@ -78,7 +78,7 @@ unique_ptr<LogicalOperator> FilterPushdown::PushdownLeftJoin(unique_ptr<LogicalO
                                                              unordered_set<idx_t> &right_bindings) {
 	auto &join = op->Cast<LogicalJoin>();
 	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
-		op = FilterPushdownUnnestWithDelimJoin(std::move(op));
+		op = PushFiltersIntoDelimJoin(std::move(op));
 		return FinishPushdown(std::move(op));
 	}
 	FilterPushdown left_pushdown(optimizer, convert_mark_joins), right_pushdown(optimizer, convert_mark_joins);

--- a/src/optimizer/pushdown/pushdown_semi_anti_join.cpp
+++ b/src/optimizer/pushdown/pushdown_semi_anti_join.cpp
@@ -12,6 +12,7 @@ using Filter = FilterPushdown::Filter;
 unique_ptr<LogicalOperator> FilterPushdown::PushdownSemiAntiJoin(unique_ptr<LogicalOperator> op) {
 	auto &join = op->Cast<LogicalJoin>();
 	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+		op = FilterPushdownUnnestWithDelimJoin(std::move(op));
 		return FinishPushdown(std::move(op));
 	}
 

--- a/src/optimizer/pushdown/pushdown_semi_anti_join.cpp
+++ b/src/optimizer/pushdown/pushdown_semi_anti_join.cpp
@@ -12,7 +12,7 @@ using Filter = FilterPushdown::Filter;
 unique_ptr<LogicalOperator> FilterPushdown::PushdownSemiAntiJoin(unique_ptr<LogicalOperator> op) {
 	auto &join = op->Cast<LogicalJoin>();
 	if (op->type == LogicalOperatorType::LOGICAL_DELIM_JOIN) {
-		op = FilterPushdownUnnestWithDelimJoin(std::move(op));
+		op = PushFiltersIntoDelimJoin(std::move(op));
 		return FinishPushdown(std::move(op));
 	}
 

--- a/test/optimizer/pushdown/issue_18653.test
+++ b/test/optimizer/pushdown/issue_18653.test
@@ -1,0 +1,58 @@
+# name: test/optimizer/pushdown/issue_18653.test
+# description: Performance issue with CROSS JOIN and LATERAL JOIN combined with unnest and json_each. Filter should be pushed down to reduce the joined rows
+# group: [pushdown]
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+create table test_table as
+select s.i as id,  [1, 2, 3]::bigint[] as values from generate_series(1, 1000000) as s(i);
+
+statement ok
+create index test_table_id_idx on test_table(id);
+
+query II
+explain analyze
+select id, value
+from test_table
+cross join unnest(values) as values(value) where id = 87100;
+----
+analyzed_plan	<REGEX>:.*LEFT_DELIM_JOIN.*FILTER.*
+
+query II
+select id, value
+from test_table
+cross join unnest(values) as values(value) where id = 87100;
+----
+87100	3
+87100	2
+87100	1
+
+query II
+explain analyze
+select id, value
+from test_table t
+left join lateral unnest(t.values) as value on true
+where id = 87100;
+----
+analyzed_plan	<REGEX>:.*LEFT_DELIM_JOIN.*FILTER.*
+
+require json
+
+statement ok
+create table test_table2 as
+select s.i as id, '{"key1": 1, "key2": 2, "key3": 3}'::JSON as values
+from generate_series(1, 1000000) as s(i);
+
+statement ok
+create index test_table2_id_idx on test_table2(id);
+
+query II
+explain analyze
+select t.id, key, value
+from test_table2 t
+cross join json_each(t.values) as kv(key, value)
+where t.id = 87100;
+----
+analyzed_plan	<REGEX>:.*LEFT_DELIM_JOIN.*Filters:.*id=87100.*

--- a/test/optimizer/unnest_rewriter.test_slow
+++ b/test/optimizer/unnest_rewriter.test_slow
@@ -123,10 +123,13 @@ EXPLAIN SELECT (SELECT UNNEST(i)) FROM (VALUES ([])) tbl(i);
 ----
 logical_opt	<REGEX>:.*DELIM_JOIN.*SINGLE.*
 
-query II
-EXPLAIN select * from (select [42, 43, 44]) t(a), (select unnest(t.a)) t2(b) where b=43;
-----
-logical_opt	<!REGEX>:.*DELIM_JOIN.*
+# Removed for now. See https://github.com/duckdb/duckdb/pull/19085
+# This query fails only on linux
+
+# query II
+# EXPLAIN select * from (select [42, 43, 44]) t(a), (select unnest(t.a)) t2(b) where b=43;
+# ----
+# logical_opt	<!REGEX>:.*DELIM_JOIN.*
 
 # test issue #7444
 

--- a/test/optimizer/unnest_rewriter.test_slow
+++ b/test/optimizer/unnest_rewriter.test_slow
@@ -123,13 +123,10 @@ EXPLAIN SELECT (SELECT UNNEST(i)) FROM (VALUES ([])) tbl(i);
 ----
 logical_opt	<REGEX>:.*DELIM_JOIN.*SINGLE.*
 
-# Removed for now. See https://github.com/duckdb/duckdb/pull/19085
-# This query fails only on linux
-
-# query II
-# EXPLAIN select * from (select [42, 43, 44]) t(a), (select unnest(t.a)) t2(b) where b=43;
-# ----
-# logical_opt	<!REGEX>:.*DELIM_JOIN.*
+query II
+EXPLAIN select * from (select [42, 43, 44]) t(a), (select unnest(t.a)) t2(b);
+----
+logical_opt	<!REGEX>:.*DELIM_JOIN.*
 
 # test issue #7444
 


### PR DESCRIPTION
Moved the logic for the ```unnest``` filter pushdown to a more suitable place to avoid unnecessary checks in ```FinishPushdown``` which is called multiple times.

In addition, I re-activated the test case that was failing only on linux before, but removed the ```where``` clause. The problem was caused because now the filter is pushed down below the ```delim join```, so the ```unnest``` rewriter optimization no longer takes place.