### PR TITLE
Fix initialization when all values are `NULL` in `SMALLER_BINARY` aggregation 

### DIFF
--- a/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -265,9 +265,9 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR> {
 
 			if (!bdata.validity.RowIsValid(bidx)) {
 				if (bind_data.null_handling == ArgMinMaxNullHandling::HANDLE_ANY_NULL && !state.is_initialized) {
-					state.is_initialized = true;
 					state.val_null = true;
 					if (!arg_null) {
+						state.is_initialized = true;
 						if (&state == last_state) {
 							assign_count--;
 						}


### PR DESCRIPTION
Fixes:

When using `arg_max_nulls_last`, queries on tables where all values are `NULL` returned a large integer (probably a placeholder as it is the same as`INT_MAX`)  instead of `NULL`.

This happens because in the aggregation phase the state was being set as initialized too early, even before any valid (non-`NULL`) values were encountered. Later, `Finalize()` assumes the state has a valid, initialized value and tries to decode it , producing the large number. If all input values are `NULL`, the state never gets properly initialized.

The fix is to only set the state as initialized when there is at least one non-NULL value.
